### PR TITLE
test count issue fix

### DIFF
--- a/examples/temp/route.ts
+++ b/examples/temp/route.ts
@@ -1,0 +1,80 @@
+const result = streamText({
+  model,
+  messages: modelMessages,
+  tools,
+  stopWhen: [stepCountIs(5)],
+})
+
+
+
+const modelMessages = convertToModelMessages(uiMessagesWithSystem)
+    const details = await describeModel({ modelId }) as SourceModel
+    const contextLimits = await getContextLimits({ modelId })
+    const result = streamText({
+      model,
+      messages: modelMessages,
+      tools,
+      stopWhen: [stepCountIs(5)],
+    })
+    return result.toUIMessageStreamResponse({
+      originalMessages: uiMessagesWithSystem,
+      generateMessageId: createIdGenerator({ size: 16 }),
+      messageMetadata:  ({ part }) => {
+        if (part.type !== 'finish') return
+        const usage = part.totalUsage
+
+        const totalTokens = usage.inputTokens! + usage.outputTokens!;
+        const remainingCombined = contextLimits?.context ? Math.max(0, contextLimits.context - totalTokens) : undefined;
+        const percentUsed = contextLimits?.context ? totalTokens / contextLimits.context : 1;
+
+        return {
+          model: modelId,
+          inputTokens: part.totalUsage.inputTokens,
+          outputTokens: part.totalUsage.outputTokens,
+          totalTokens: part.totalUsage.totalTokens,
+          reasoningTokens: part.totalUsage.reasoningTokens,
+          cachedInputTokens: part.totalUsage.cachedInputTokens,
+          createdAt: Date.now(),
+          contextUsedPercent: percentUsed,
+          remainingTokens: remainingCombined,
+          contextHealth: percentUsed > 0.85 ? 'compact' : percentUsed > 0.75 ? 'warn' : 'ok',
+          estimatedCostUSD: 0,
+          limit: contextLimits,
+        }
+      },
+      onFinish: async ({ messages }) => {
+        try {
+          const pm = await result.providerMetadata
+          const usage = pm?.openrouter?.usage
+          console.log("THIS IS THE USAGE from openrouter", usage)
+          const lastMessage = messages[messages.length - 1]
+ 
+          if (lastMessage?.role === 'assistant') {
+            const m = (lastMessage.metadata ?? {}) as any
+            const usage: Usage = {
+              input_tokens: m.inputTokens ?? 0,
+              output_tokens: m.outputTokens ?? 0,
+              total_tokens: m.totalTokens ?? 0,
+              reasoning_tokens: m.reasoningTokens ?? 0,
+              cache_read_tokens: m.cachedInputTokens ?? 0,
+            }
+            console.log("THIS IS THE USAGE", JSON.stringify(usage))
+            const modelSlice = modelId.split('/')[1]
+            console.log("THIS IS THE MODEL SLICE", modelSlice)
+            const estimatedCostUSD = await computeCostUSD({ modelId: modelId, provider: "openrouter", usage })
+            console.log("THIS IS THE ESTIMATED COST USD", estimatedCostUSD)
+            lastMessage.metadata = { ...m, estimatedCostUSD }
+          }
+          await saveChatUI(id, userId, messages as UIMessage[])
+        } catch (error: unknown) {
+          const errorMessage = error instanceof Error ? error.message : 'Unknown error'
+          console.error('Failed to save UI messages:', errorMessage)
+        }
+      },
+      sendReasoning: true,
+      onError: (error: unknown) => {
+        const message = error instanceof Error ? error.message : String(error)
+        console.error('UI stream error:', message)
+        return message
+      },
+    })

--- a/packages/fetch/src/index.ts
+++ b/packages/fetch/src/index.ts
@@ -126,37 +126,40 @@ function mapOpenrouterModel(m: Record<string, unknown>): SourceModel {
       output?: string[];
     })
     : undefined;
-  const rawCost = (m["pricing"] as Record<string, string | number> | undefined) ??
-    (m["cost"] as Record<string, string | number> | undefined);
+    const cost =
+    (m["pricing"] as Record<string, number> | undefined) ??
+    (m["cost"] as Record<string, number> | undefined);
+  // const rawCost = (m["pricing"] as Record<string, string | number> | undefined) ??
+  //   (m["cost"] as Record<string, string | number> | undefined);
 
-  // Convert OpenRouter per-token costs to per-million-token costs
-  const cost = rawCost ? {
-    ...(rawCost['prompt'] !== undefined ? {
-      input: typeof rawCost['prompt'] === 'string' ?
-        parseFloat(rawCost['prompt']) :
-        rawCost['prompt']
-    } : {}),
-    ...(rawCost['completion'] !== undefined ? {
-      output: typeof rawCost['completion'] === 'string' ?
-        parseFloat(rawCost['completion']) :
-        rawCost['completion']
-    } : {}),
-    ...(rawCost['internal_reasoning'] !== undefined ? {
-      reasoning: typeof rawCost['internal_reasoning'] === 'string' ?
-        parseFloat(rawCost['internal_reasoning']) :
-        rawCost['internal_reasoning']
-    } : {}),
-    ...(rawCost['input_cache_read'] !== undefined ? {
-      cache_read: typeof rawCost['input_cache_read'] === 'string' ?
-        parseFloat(rawCost['input_cache_read']) :
-        rawCost['input_cache_read']
-    } : {}),
-    ...(rawCost['input_cache_write'] !== undefined ? {
-      cache_write: typeof rawCost['input_cache_write'] === 'string' ?
-        parseFloat(rawCost['input_cache_write']) :
-        rawCost['input_cache_write']
-    } : {}),
-  } : undefined;
+  // // Convert OpenRouter per-token costs to per-million-token costs
+  // const cost = rawCost ? {
+  //   ...(rawCost['prompt'] !== undefined ? {
+  //     input: typeof rawCost['prompt'] === 'string' ?
+  //       parseFloat(rawCost['prompt']) :
+  //       rawCost['prompt']
+  //   } : {}),
+  //   ...(rawCost['completion'] !== undefined ? {
+  //     output: typeof rawCost['completion'] === 'string' ?
+  //       parseFloat(rawCost['completion']) :
+  //       rawCost['completion']
+  //   } : {}),
+  //   ...(rawCost['internal_reasoning'] !== undefined ? {
+  //     reasoning: typeof rawCost['internal_reasoning'] === 'string' ?
+  //       parseFloat(rawCost['internal_reasoning']) :
+  //       rawCost['internal_reasoning']
+  //   } : {}),
+  //   ...(rawCost['input_cache_read'] !== undefined ? {
+  //     cache_read: typeof rawCost['input_cache_read'] === 'string' ?
+  //       parseFloat(rawCost['input_cache_read']) :
+  //       rawCost['input_cache_read']
+  //   } : {}),
+  //   ...(rawCost['input_cache_write'] !== undefined ? {
+  //     cache_write: typeof rawCost['input_cache_write'] === 'string' ?
+  //       parseFloat(rawCost['input_cache_write']) :
+  //       rawCost['input_cache_write']
+  //   } : {}),
+  // } : undefined;
   const limit =
     (m["limit"] as
       | { context?: number; input?: number; output?: number }

--- a/packages/helpers/src/internal.ts
+++ b/packages/helpers/src/internal.ts
@@ -65,5 +65,5 @@ export function perMTokensToUnitCostUSD(
 }
 
 export function round6(n: number): number {
-  return Math.round(n * 1_000_000) / 1_000_000;
+  return Math.round(n * 1_000_00000000) / 1_000_00000000;
 }

--- a/packages/helpers/src/internal.ts
+++ b/packages/helpers/src/internal.ts
@@ -64,6 +64,10 @@ export function perMTokensToUnitCostUSD(
   return (tokens * ratePerMTokens) / 1_000_000;
 }
 
-export function round6(n: number): number {
+export function round12(n: number): number {
   return Math.round(n * 1_000_00000000) / 1_000_00000000;
+}
+
+export function round6(n: number): number {
+  return Math.round(n * 1_000_000) / 1_000_000;
 }

--- a/packages/tokenlens/tests/client.test.ts
+++ b/packages/tokenlens/tests/client.test.ts
@@ -78,6 +78,15 @@ function makeUsage(): Usage {
   } satisfies Usage;
 }
 
+function makeUsageWithSmallValues(): Usage {
+  return {
+    input_tokens: 5160,
+    output_tokens: 14,
+    reasoning_tokens: 0,
+    cache_read_tokens: 4918,
+  } satisfies Usage;
+}
+
 describe("Tokenlens core", () => {
   afterEach(() => {
     vi.restoreAllMocks();
@@ -101,7 +110,7 @@ describe("Tokenlens core", () => {
     });
 
     const first = await client.getProviders();
-    expect(Object.keys(first)).toEqual(["openai", "anthropic", "local"]);
+    expect(Object.keys(first)).toEqual(["openai", "google", "anthropic", "local"]);
     expect(openrouterCtrl.getCalls()).toBe(1);
     expect(modelsDevCtrl.getCalls()).toBe(1);
 
@@ -368,6 +377,22 @@ describe("module-level helpers", () => {
     });
     expect(costs.totalTokenCostUSD).toBeCloseTo(0.1023, 6);
   });
+
+
+  it("computeCostUSD for google gemini flash", async () => {
+    const { tokenlens } = setupSharedInstance();
+    const usage = makeUsageWithSmallValues();
+    const costs = await tokenlens.computeCostUSD({
+      modelId: "google/gemini-2.5-flash-lite-preview-09-2025",
+      usage,
+    });
+    console.log("costs for small values", costs);
+    console.log("usage in method", usage);
+    expect(costs.inputTokenCostUSD).toBe(0);
+    expect(costs.outputTokenCostUSD).toBe(0);
+    expect(costs.totalTokenCostUSD).toBe(0);
+  });
+
 
   it("describeModel reuses cached providers", async () => {
     const { tokenlens } = setupSharedInstance();

--- a/packages/tokenlens/tests/fixtures/providers.ts
+++ b/packages/tokenlens/tests/fixtures/providers.ts
@@ -16,6 +16,23 @@ const OPENAI_GPT4O_MODEL: SourceModel = {
     cache_read: 6,
   },
 };
+const GOOGLE_GEMINI_FLASH_LITE_MODEL: SourceModel = {
+  id: "google/gemini-2.5-flash-lite-preview-09-2025",
+  name: "Google: Gemini 2.5 Flash Lite Preview 09-2025",
+  reasoning: false,
+  tool_call: true,
+  attachment: true,
+  open_weights: false,
+  knowledge: "2025-01",
+  limit: { context: 1_048_576, output: 65_536 },
+  cost: {
+    input: 0.0000003,
+    output: 0.0000025,
+    reasoning: 0,
+    cache_read: 0.000000075,
+    cache_write: 0.0000003833,
+  },
+};
 
 const OPENROUTER_PROVIDERS: SourceProviders = {
   openai: {
@@ -28,6 +45,18 @@ const OPENROUTER_PROVIDERS: SourceProviders = {
     schemaVersion: 1,
     models: {
       [OPENAI_GPT4O_MODEL.id]: OPENAI_GPT4O_MODEL,
+    },
+  },
+  google: {
+    id: "google",
+    name: "Google",
+    api: "https://openrouter.ai/api/v1",
+    doc: "https://openrouter.ai/models",
+    env: ["OPENROUTER_API_KEY"],
+    source: "openrouter",
+    schemaVersion: 1,
+    models: {
+      [GOOGLE_GEMINI_FLASH_LITE_MODEL.id]: GOOGLE_GEMINI_FLASH_LITE_MODEL,
     },
   },
 };
@@ -74,6 +103,7 @@ const PACKAGE_PROVIDERS: SourceProviders = {
     },
   },
 };
+
 
 function cloneProviders(providers: SourceProviders): SourceProviders {
   return JSON.parse(JSON.stringify(providers)) as SourceProviders;


### PR DESCRIPTION
I think the problem is two fold
1. From open router we are getting string so we need to parse them
2. and the rounding is doing up to 6 which is problem if we have less than million token (basically any cost which less than 6 0's is getting dropped)
3 What i have understood so far, whe have way few tokens when we are calculating for very few tokens ex 25 tokens then when converting to per million we get 7.5E-12 and when we are rounding down few steps later we are getting zero. 

```
export function perMTokensToUnitCostUSD(
  tokens: number,
  ratePerMTokens?: number,
): number {
  if (!ratePerMTokens || ratePerMTokens < 0 || !Number.isFinite(tokens))
    return 0;
  return (tokens * ratePerMTokens) / 1_000_000;
}
```

```
cost {
  inputTokenCostUSD: 1.5,
  outputTokenCostUSD: 3.5e-7,
  cacheReadTokenCostUSD: 3.7e-10,
  totalTokenCostUSD: 1.50000035037,
  ratesUsed: {
    inputPerMTokens: 3e-7,
    outputPerMTokens: 0.0000025,
    reasoningPerMTokens: 0,
    cacheReadPerMTokens: 7.5e-8,
    cacheWritePerMTokens: 3.833e-7
  }
}
```
```
This is for   "id": "google/gemini-2.5-flash-preview-09-2025", and this already gives prices per million
     "pricing": {
        "prompt": "0.0000003",
        "completion": "0.0000025",
        "request": "0",
        "image": "0.001238",
        "web_search": "0",
        "internal_reasoning": "0",
        "input_cache_read": "0.000000075",
        "input_cache_write": "0.0000003833"
      },
```

Added a test case and in examples/temp/route.ts i have added my streamText function. I was doing a lot of custom tranformation to see if any will give me the computeCost .


