### PR TITLE
Remove ModelId import in README

### DIFF
--- a/packages/tokenlens/README.md
+++ b/packages/tokenlens/README.md
@@ -29,14 +29,13 @@ Install
 Quick Start
 ```ts
 import {
-  type ModelId,
   modelMeta,
   percentOfContextUsed,
   tokensRemaining,
   costFromUsage,
 } from 'tokenlens';
 
-const id: ModelId = 'openai:gpt-4.1';
+const id = 'openai:gpt-4.1';
 // Works with provider usage or Vercel AI SDK usage
 const usage = { prompt_tokens: 3200, completion_tokens: 400 };
 


### PR DESCRIPTION
Model ids are plain `string` in v1.3+. The readme of the repo is up to date, but the readme of the tokenlens package — and thus what's shown on `npm` — is out of date.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Simplified Quick Start code example with reduced type annotations for improved clarity and better developer experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->