### PR TITLE
fix: address v2 merge blockers

### DIFF
--- a/apps/web-demo/src/app/page.tsx
+++ b/apps/web-demo/src/app/page.tsx
@@ -1,8 +1,5 @@
-import { fetchModels } from "tokenlens";
 import InputDemo from "@/components/chat";
 
-export default async function Home() {
-  const allModels = await fetchModels({ provider: "vercel" });
-  console.log(allModels);
+export default function Home() {
   return <InputDemo />;
 }

--- a/apps/web-demo/src/components/ai-elements/context.tsx
+++ b/apps/web-demo/src/components/ai-elements/context.tsx
@@ -2,7 +2,6 @@
 
 import type { LanguageModelUsage } from "ai";
 import type { ComponentProps } from "react";
-import { breakdownTokens, estimateCost, normalizeUsage } from "tokenlens";
 import {
   HoverCard,
   HoverCardContent,
@@ -35,6 +34,17 @@ const ICON_CENTER = 12;
 const ICON_RADIUS = 10;
 const ICON_STROKE_WIDTH = 2;
 
+function normalizeUsage(usage?: LanguageModelUsage) {
+  return {
+    input: usage?.inputTokens ?? 0,
+    output: usage?.outputTokens ?? 0,
+    total: usage?.totalTokens,
+    reasoningTokens: usage?.reasoningTokens,
+    cacheReads: usage?.cachedInputTokens,
+    cacheWrites: undefined,
+  };
+}
+
 const formatTokens = (tokens?: number) => {
   if (tokens === undefined) {
     return;
@@ -63,22 +73,6 @@ const formatPercent = (value: number) => {
   return Number.isInteger(rounded)
     ? `${Math.trunc(rounded)}%`
     : `${rounded.toFixed(1)}%`;
-};
-
-const formatUSD = (value?: number) => {
-  if (value === undefined || !Number.isFinite(value)) return undefined;
-  const abs = Math.abs(value);
-  // Finer precision for very small amounts common in LLM pricing
-  let decimals = 2;
-  if (abs < 0.001) decimals = 5;
-  else if (abs < 0.01) decimals = 4;
-  else if (abs < 0.1) decimals = 3;
-  else if (abs < 10) decimals = 2;
-  else decimals = 1;
-  const text = value.toFixed(decimals);
-  // Trim trailing zeros/decimal if not needed (e.g., 1.2300 -> 1.23, 2.0 -> 2)
-  const trimmed = text.replace(/\.0+$/, "").replace(/(\.\d*?)0+$/, "$1");
-  return `$${trimmed}`;
 };
 
 type ContextIconProps = {
@@ -130,7 +124,7 @@ export const Context = ({
   maxTokens,
   usedTokens,
   usage,
-  modelId,
+  modelId: _modelId,
   showBreakdown,
   ...props
 }: ContextProps) => {
@@ -150,16 +144,12 @@ export const Context = ({
   const total = formatTokens(safeMax);
 
   const uNorm = normalizeUsage(usage);
-  const uBreakdown = breakdownTokens(usage);
-  const costUSD = modelId
-    ? estimateCost({ modelId, usage: uNorm }).totalUSD
-    : undefined;
-  const costText = formatUSD(costUSD);
+  const costText = undefined;
 
   const segInput = Math.max(0, uNorm.input ?? 0);
   const segOutput = Math.max(0, uNorm.output ?? 0);
-  const segCacheR = Math.max(0, uBreakdown.cacheReads ?? 0);
-  const segCacheW = Math.max(0, uBreakdown.cacheWrites ?? 0);
+  const segCacheR = Math.max(0, uNorm.cacheReads ?? 0);
+  const segCacheW = Math.max(0, uNorm.cacheWrites ?? 0);
   const denom = safeMax > 0 ? safeMax : 1;
   const w = (n: number) =>
     `${Math.min(100, Math.max(0, (n / denom) * 100)).toFixed(2)}%`;
@@ -238,7 +228,7 @@ export const Context = ({
                     />
                     Cache Hits
                   </span>
-                  <span>{fmtOrUnknown(uBreakdown.cacheReads)}</span>
+                  <span>{fmtOrUnknown(uNorm.cacheReads)}</span>
                 </div>
                 <div className="flex items-center justify-between">
                   <span className="flex items-center gap-2 text-muted-foreground">
@@ -248,7 +238,7 @@ export const Context = ({
                     />
                     Cache Writes
                   </span>
-                  <span>{fmtOrUnknown(uBreakdown.cacheWrites)}</span>
+                  <span>{fmtOrUnknown(uNorm.cacheWrites)}</span>
                 </div>
                 <div className="flex items-center justify-between">
                   <span className="flex items-center gap-2 text-muted-foreground">
@@ -277,11 +267,11 @@ export const Context = ({
             <div className="mt-1 space-y-1">
               <div className="flex items-center justify-between text-xs">
                 <span className="text-muted-foreground">Cache Hits</span>
-                <span>{fmtOrUnknown(uBreakdown.cacheReads)}</span>
+                <span>{fmtOrUnknown(uNorm.cacheReads)}</span>
               </div>
               <div className="flex items-center justify-between text-xs">
                 <span className="text-muted-foreground">Cache Writes</span>
-                <span>{fmtOrUnknown(uBreakdown.cacheWrites)}</span>
+                <span>{fmtOrUnknown(uNorm.cacheWrites)}</span>
               </div>
               <div className="flex items-center justify-between text-xs">
                 <span className="text-muted-foreground">Input</span>

--- a/apps/web-demo/src/components/ai-elements/inline-citation.tsx
+++ b/apps/web-demo/src/components/ai-elements/inline-citation.tsx
@@ -68,7 +68,7 @@ export const InlineCitationCardTrigger = ({
       variant="secondary"
       {...props}
     >
-      {sources.length ? (
+      {sources[0] ? (
         <>
           {new URL(sources[0]).hostname}{" "}
           {sources.length > 1 && `+${sources.length - 1}`}

--- a/apps/web-demo/src/components/ai-elements/reasoning.tsx
+++ b/apps/web-demo/src/components/ai-elements/reasoning.tsx
@@ -54,7 +54,7 @@ export const Reasoning = memo(
     const [isOpen, setIsOpen] = useControllableState({
       prop: open,
       defaultProp: defaultOpen,
-      onChange: onOpenChange,
+      ...(onOpenChange ? { onChange: onOpenChange } : {}),
     });
     const [duration, setDuration] = useControllableState({
       prop: durationProp,
@@ -87,6 +87,7 @@ export const Reasoning = memo(
 
         return () => clearTimeout(timer);
       }
+      return undefined;
     }, [isStreaming, isOpen, defaultOpen, setIsOpen, hasAutoClosedRef]);
 
     const handleOpenChange = (newOpen: boolean) => {

--- a/apps/web-demo/src/components/chat.tsx
+++ b/apps/web-demo/src/components/chat.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { useChat } from "@ai-sdk/react";
-import { getContext, normalizeUsage } from "@tokenlens/helpers";
 import type { LanguageModelUsage, UIMessage } from "ai";
 import { GlobeIcon, MicIcon } from "lucide-react";
 import { useEffect, useMemo, useState } from "react";
@@ -28,16 +27,24 @@ import { Response } from "@/components/ai-elements/response";
 import { Context } from "./ai-elements/context";
 
 const models = [
-  { id: "gpt-4o", name: "GPT-4o" },
-  { id: "gpt-5", name: "GPT-5" },
-  { id: "claude-opus-4-20250514", name: "Claude 4 Opus" },
+  { id: "gpt-4o", name: "GPT-4o", context: 128_000 },
+  { id: "gpt-5", name: "GPT-5", context: 200_000 },
+  { id: "claude-opus-4-20250514", name: "Claude 4 Opus", context: 200_000 },
 ];
 
 type AppUIMessage = UIMessage<unknown, { usage: LanguageModelUsage }>;
 
+function normalizeUsage(usage: LanguageModelUsage) {
+  return {
+    input: usage.inputTokens ?? 0,
+    output: usage.outputTokens ?? 0,
+    total: usage.totalTokens,
+  };
+}
+
 const InputDemo = () => {
   const [text, setText] = useState<string>("");
-  const [model, setModel] = useState<string>(models[0].id);
+  const [model, setModel] = useState<string>(models[0]?.id ?? "gpt-4o");
   const [usage, setUsage] = useState<LanguageModelUsage | undefined>(undefined);
 
   const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
@@ -62,13 +69,9 @@ const InputDemo = () => {
     },
   });
 
-  const catalog = useMemo(() => catalogFromProviders([vercelModels]), []);
-
   const contextMax = useMemo(() => {
-    // Resolve from selected model within the selected provider source.
-    const cw = getContextWindow(model, { catalog });
-    return cw.combinedMax ?? cw.inputMax ?? 0;
-  }, [model, catalog]);
+    return models.find((entry) => entry.id === model)?.context ?? 0;
+  }, [model]);
 
   const usedTokens = useMemo(() => {
     // Prefer explicit usage data part captured via onData

--- a/apps/web-demo/src/lib/utils.ts
+++ b/apps/web-demo/src/lib/utils.ts
@@ -18,5 +18,5 @@ export function onCompactThreshold(listener: (e: CompactEvent) => void) {
   compactListeners.push(listener);
 }
 export const COMPACT_THRESHOLD = Number(
-  process.env.COMPACT_THRESHOLD ?? "0.85",
+  process.env["COMPACT_THRESHOLD"] ?? "0.85",
 );

--- a/apps/www/src/app/(home)/layout.tsx
+++ b/apps/www/src/app/(home)/layout.tsx
@@ -1,7 +1,12 @@
 import { HomeLayout } from "fumadocs-ui/layouts/home";
+import type { ReactNode } from "react";
 import { baseOptions } from "@/lib/layout.shared";
 
-export default async function Layout({ children }: LayoutProps<"/">) {
+type LayoutProps = {
+  children: ReactNode;
+};
+
+export default async function Layout({ children }: LayoutProps) {
   const options = await baseOptions();
   return <HomeLayout {...options}>{children}</HomeLayout>;
 }

--- a/apps/www/src/app/docs/[[...slug]]/page.tsx
+++ b/apps/www/src/app/docs/[[...slug]]/page.tsx
@@ -11,7 +11,11 @@ import { LLMCopyButton, ViewOptions } from "@/components/page-actions";
 import { getPageImage, source } from "@/lib/source";
 import { getMDXComponents } from "@/mdx-components";
 
-export default async function Page(props: PageProps<"/docs/[[...slug]]">) {
+type DocsPageProps = {
+  params: Promise<{ slug?: string[] }>;
+};
+
+export default async function Page(props: DocsPageProps) {
   const params = await props.params;
   const page = source.getPage(params.slug);
   if (!page) notFound();
@@ -46,7 +50,7 @@ export async function generateStaticParams() {
 }
 
 export async function generateMetadata(
-  props: PageProps<"/docs/[[...slug]]">,
+  props: DocsPageProps,
 ): Promise<Metadata> {
   const params = await props.params;
   const page = source.getPage(params.slug);

--- a/apps/www/src/app/docs/layout.tsx
+++ b/apps/www/src/app/docs/layout.tsx
@@ -1,8 +1,13 @@
 import { DocsLayout } from "fumadocs-ui/layouts/docs";
+import type { ReactNode } from "react";
 import { baseOptions } from "@/lib/layout.shared";
 import { source } from "@/lib/source";
 
-export default async function Layout({ children }: LayoutProps<"/docs">) {
+type LayoutProps = {
+  children: ReactNode;
+};
+
+export default async function Layout({ children }: LayoutProps) {
   const options = await baseOptions();
   return (
     <DocsLayout tree={source.pageTree} {...options}>

--- a/apps/www/src/app/layout.tsx
+++ b/apps/www/src/app/layout.tsx
@@ -2,6 +2,7 @@ import "@/app/global.css";
 import { RootProvider } from "fumadocs-ui/provider/next";
 import type { Metadata } from "next";
 import { Inter } from "next/font/google";
+import type { ReactNode } from "react";
 
 const inter = Inter({
   subsets: ["latin"],
@@ -42,7 +43,11 @@ export const metadata: Metadata = {
   },
 };
 
-export default function Layout({ children }: LayoutProps<"/">) {
+type LayoutProps = {
+  children: ReactNode;
+};
+
+export default function Layout({ children }: LayoutProps) {
   return (
     <html lang="en" className={inter.className} suppressHydrationWarning>
       <body className="flex flex-col min-h-screen">

--- a/apps/www/src/app/og/docs/[...slug]/route.tsx
+++ b/apps/www/src/app/og/docs/[...slug]/route.tsx
@@ -5,10 +5,11 @@ import { getPageImage, source } from "@/lib/source";
 
 export const revalidate = false;
 
-export async function GET(
-  _req: Request,
-  { params }: RouteContext<"/og/docs/[...slug]">,
-) {
+type DocsOgRouteContext = {
+  params: Promise<{ slug: string[] }>;
+};
+
+export async function GET(_req: Request, { params }: DocsOgRouteContext) {
   const { slug } = await params;
   const page = source.getPage(slug.slice(0, -1));
   if (!page) notFound();

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "sync:readme": "node scripts/sync-readmes.mjs root",
     "sync:pkg-readmes": "node scripts/sync-readmes.mjs packages",
     "sync:readmes": "node scripts/sync-readmes.mjs",
-    "pre-release": "pnpm --filter tokenlens run gen:providers && pnpm format --fix && pnpm run build && pnpm run test:run",
+    "pre-release": "pnpm format --fix && pnpm run build && pnpm run test:run",
     "prerelease": "pnpm run pre-release",
     "release": "pnpm -r publish --access public --filter=\"@tokenlens/*\" --filter=tokenlens",
     "release:force": "pnpm -r publish --access public --filter=\"@tokenlens/*\" --filter=tokenlens --no-git-checks"

--- a/packages/tokenlens/package.json
+++ b/packages/tokenlens/package.json
@@ -14,14 +14,6 @@
       "types": "./dist/index.d.ts",
       "default": "./dist/index.js"
     },
-    "./providers/*": {
-      "types": "./dist/exports/providers/*.d.ts",
-      "default": "./dist/exports/providers/*.js"
-    },
-    "./models": {
-      "types": "./dist/exports/models.d.ts",
-      "default": "./dist/exports/models.js"
-    },
     "./helpers": {
       "types": "./dist/exports/helpers.d.ts",
       "default": "./dist/exports/helpers.js"

--- a/packages/tokenlens/src/exports/core.ts
+++ b/packages/tokenlens/src/exports/core.ts
@@ -1,0 +1,1 @@
+export * from "@tokenlens/core";

--- a/packages/tokenlens/src/exports/fetch.ts
+++ b/packages/tokenlens/src/exports/fetch.ts
@@ -1,0 +1,1 @@
+export * from "@tokenlens/fetch";

--- a/packages/tokenlens/src/exports/helpers.ts
+++ b/packages/tokenlens/src/exports/helpers.ts
@@ -1,0 +1,1 @@
+export * from "@tokenlens/helpers";

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -27,6 +27,18 @@ function project(
 }
 
 export default defineConfig({
+  resolve: {
+    alias: {
+      "@tokenlens/core": resolve(repoRoot, "packages/core/src/index.ts"),
+      "@tokenlens/fetch": resolve(repoRoot, "packages/fetch/src/index.ts"),
+      "@tokenlens/helpers": resolve(repoRoot, "packages/helpers/src/index.ts"),
+      "@tokenlens/tokenizer": resolve(
+        repoRoot,
+        "packages/tokenizer/src/index.ts",
+      ),
+      tokenlens: resolve(repoRoot, "packages/tokenlens/src/index.ts"),
+    },
+  },
   test: {
     coverage: {
       reporter: ["text", "json", "html"],
@@ -36,7 +48,6 @@ export default defineConfig({
       project("core", "packages/core", ["tests/**/*.test.ts"]),
       project("helpers", "packages/helpers", ["tests/**/*.spec.ts"]),
       project("fetch", "packages/fetch", ["tests/**/*.spec.ts"]),
-      project("models", "packages/models", ["tests/**/*.spec.ts"]),
       project("tokenizer", "packages/tokenizer", ["tests/**/*.spec.ts"], {
         globals: true,
       }),


### PR DESCRIPTION
## Summary
- alias workspace packages to source in Vitest so package tests pass in fresh checkouts
- replace Next generated route globals in docs app with explicit prop types
- remove stale tokenlens package export targets and restore valid core/fetch/helpers subpath shims
- update web demo references to removed tokenlens APIs so it typechecks

## Validation
- pnpm run format
- pnpm exec biome lint --reporter=summary packages
- pnpm run typecheck
- pnpm run build
- pnpm run test:run
- pnpm -r "--filter=./packages/*" --if-present test:run
- pnpm exec tsc -p apps/web-demo/tsconfig.json --noEmit
- git diff --check

Note: Biome reports existing warnings, but exits 0.