### PR TITLE
Fix custom fetch, stale cache fallback, and example validation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,6 +66,9 @@ jobs:
       - name: Build packages only (turbo)
         run: pnpm turbo run build --filter=./packages/*
 
+      - name: Typecheck examples
+        run: pnpm turbo run typecheck --filter=./examples/*
+
   test:
     name: Test
     runs-on: ubuntu-latest

--- a/examples/anthropic-sdk/package.json
+++ b/examples/anthropic-sdk/package.json
@@ -3,7 +3,8 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "start": "tsx src/index.ts"
+    "start": "tsx src/index.ts",
+    "typecheck": "tsc --noEmit"
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.63.1",

--- a/examples/openai-sdk/package.json
+++ b/examples/openai-sdk/package.json
@@ -3,7 +3,8 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "start": "tsx src/index.ts"
+    "start": "tsx src/index.ts",
+    "typecheck": "tsc --noEmit"
   },
   "dependencies": {
     "dotenv": "^17.2.2",

--- a/examples/openai-sdk/src/index.ts
+++ b/examples/openai-sdk/src/index.ts
@@ -9,7 +9,6 @@ import {
 } from "tokenlens";
 
 const MODEL_ID = "openai/gpt-4o-mini";
-const PROVIDER = "openai";
 
 async function main(): Promise<void> {
   const apiKey = process.env["OPENAI_API_KEY"];
@@ -160,7 +159,7 @@ async function main(): Promise<void> {
   console.log(`Total output tokens: ${totalOutputTokens}`);
   console.log(`Estimated cost: $${totalCost.toFixed(6)}`);
 
-  console.log("\n" + "=".repeat(60));
+  console.log(`\n${"=".repeat(60)}`);
   console.log("✅ Example completed successfully!");
 }
 

--- a/examples/vercel-ai-sdk/package.json
+++ b/examples/vercel-ai-sdk/package.json
@@ -3,7 +3,8 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "start": "tsx src/index.ts"
+    "start": "tsx src/index.ts",
+    "typecheck": "tsc --noEmit"
   },
   "dependencies": {
     "@ai-sdk/openai": "^2.0.35",
@@ -12,6 +13,7 @@
     "tokenlens": "workspace:*"
   },
   "devDependencies": {
+    "@types/node": "^24.5.2",
     "tsx": "^4.20.5"
   }
 }

--- a/examples/vercel-ai-sdk/src/index.ts
+++ b/examples/vercel-ai-sdk/src/index.ts
@@ -5,7 +5,6 @@ import {
   compactJson,
   computeCostUSD,
   countTokens,
-  createTokenlens,
   estimateCostUSD,
   getContextHealth,
 } from "tokenlens";
@@ -17,8 +16,6 @@ async function main(): Promise<void> {
     process.exitCode = 1;
     return;
   }
-
-  const tokenlens = createTokenlens();
 
   console.log("🎯 TokenLens + Vercel AI SDK Example\n");
   console.log("=".repeat(60));
@@ -145,7 +142,7 @@ async function main(): Promise<void> {
     `Decision: ${estimate.totalTokenCostUSD > 0.01 ? "⚠️ High cost" : "✅ Proceed"}`,
   );
 
-  console.log("\n" + "=".repeat(60));
+  console.log(`\n${"=".repeat(60)}`);
   console.log("✅ Example completed successfully!");
 }
 

--- a/packages/fetch/src/index.ts
+++ b/packages/fetch/src/index.ts
@@ -14,6 +14,7 @@ export type {
 type CommonOptions = {
   provider?: string;
   model?: string;
+  fetch?: typeof globalThis.fetch;
 };
 
 function filterCatalog(
@@ -40,7 +41,8 @@ function filterCatalog(
 export async function fetchModelsDev(
   options?: CommonOptions,
 ): Promise<SourceProviders> {
-  const res = await fetch("https://models.dev/api.json");
+  const fetchImpl = options?.fetch ?? globalThis.fetch;
+  const res = await fetchImpl("https://models.dev/api.json");
   if (!res.ok) {
     throw new TokenlensError.FetchFailed({
       target: "models.dev",
@@ -198,7 +200,8 @@ function mapVercelModel(model: VercelModelJson): SourceModel {
 export async function fetchVercel(
   options?: CommonOptions,
 ): Promise<SourceProviders> {
-  const res = await fetch("https://ai-gateway.vercel.sh/v1/models");
+  const fetchImpl = options?.fetch ?? globalThis.fetch;
+  const res = await fetchImpl("https://ai-gateway.vercel.sh/v1/models");
   if (!res.ok) {
     throw new TokenlensError.FetchFailed({
       target: "Vercel AI Gateway",
@@ -244,7 +247,8 @@ export async function fetchVercel(
 export async function fetchOpenrouter(
   options?: CommonOptions,
 ): Promise<SourceProviders> {
-  const res = await fetch("https://openrouter.ai/api/v1/models");
+  const fetchImpl = options?.fetch ?? globalThis.fetch;
+  const res = await fetchImpl("https://openrouter.ai/api/v1/models");
   if (!res.ok) {
     throw new TokenlensError.FetchFailed({
       target: "OpenRouter",

--- a/packages/fetch/tests/fetch.spec.ts
+++ b/packages/fetch/tests/fetch.spec.ts
@@ -1,6 +1,85 @@
 import { writeFile } from "node:fs/promises";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { fetchModelsDev, fetchOpenrouter, fetchVercel } from "../src/index.ts";
+
+const jsonResponse = (body: unknown): Response =>
+  ({
+    ok: true,
+    status: 200,
+    statusText: "OK",
+    json: async () => body,
+  }) as Response;
+
+describe("fetch injection", () => {
+  it("fetchOpenrouter uses the provided fetch implementation", async () => {
+    const fetchImpl = vi.fn<typeof globalThis.fetch>(async () =>
+      jsonResponse({
+        data: [
+          {
+            id: "openai/gpt-4o",
+            name: "GPT-4o",
+            pricing: { prompt: "0.0000025", completion: "0.00001" },
+            context_length: 128_000,
+          },
+        ],
+      }),
+    );
+
+    const providers = await fetchOpenrouter({ fetch: fetchImpl });
+
+    expect(fetchImpl).toHaveBeenCalledWith(
+      "https://openrouter.ai/api/v1/models",
+    );
+    expect(providers.openai.models["openai/gpt-4o"]?.cost?.input).toBe(2.5);
+  });
+
+  it("fetchModelsDev uses the provided fetch implementation", async () => {
+    const fetchImpl = vi.fn<typeof globalThis.fetch>(async () =>
+      jsonResponse({
+        openai: {
+          id: "openai",
+          models: {
+            "openai/gpt-4o": {
+              id: "openai/gpt-4o",
+              canonical_id: "openai/gpt-4o",
+              name: "GPT-4o",
+            },
+          },
+        },
+      }),
+    );
+
+    const providers = await fetchModelsDev({ fetch: fetchImpl });
+
+    expect(fetchImpl).toHaveBeenCalledWith("https://models.dev/api.json");
+    expect(providers.openai.models["openai/gpt-4o"]?.name).toBe("GPT-4o");
+  });
+
+  it("fetchVercel uses the provided fetch implementation", async () => {
+    const fetchImpl = vi.fn<typeof globalThis.fetch>(async () =>
+      jsonResponse({
+        data: [
+          {
+            id: "openai/gpt-4o",
+            name: "GPT-4o",
+            owned_by: "openai",
+            pricing: { prompt: "0.0000025", completion: "0.00001" },
+            context_window: 128_000,
+          },
+        ],
+      }),
+    );
+
+    const providers = await fetchVercel({ fetch: fetchImpl });
+
+    expect(fetchImpl).toHaveBeenCalledWith(
+      "https://ai-gateway.vercel.sh/v1/models",
+    );
+    expect(providers.openai.models["openai/gpt-4o"]?.limit?.context).toBe(
+      128_000,
+    );
+  });
+});
 
 describe("live fetchers", () => {
   it("fetchOpenrouter returns catalog with providers and models", async () => {

--- a/packages/tokenlens/package.json
+++ b/packages/tokenlens/package.json
@@ -76,6 +76,7 @@
   },
   "homepage": "https://github.com/xn1cklas/tokenlens/tree/HEAD/packages/tokenlens#readme",
   "devDependencies": {
+    "@types/node": "^24.5.2",
     "typescript": "^5.9.3"
   },
   "dependencies": {

--- a/packages/tokenlens/src/client.ts
+++ b/packages/tokenlens/src/client.ts
@@ -27,18 +27,43 @@ export class Tokenlens {
   private readonly ttlMs: number;
   private readonly cache: CacheAdapter;
   private readonly cacheKey: string;
+  private readonly fetchImpl: typeof globalThis.fetch;
 
   constructor(options?: TokenlensOptions) {
     // use automode as default
     this.catalog = options?.catalog ?? GATEWAY_IDS[1];
     this.ttlMs = options?.ttlMs ?? 24 * 60 * 60 * 1000;
     this.cache = options?.cache ?? new MemoryCache();
+    this.fetchImpl = options?.fetch ?? globalThis.fetch;
 
     // only cache when we load the catalog form a gateway
     if (typeof this.catalog === "string") {
       this.cacheKey = options?.cacheKey ?? `tokenlens:v2:${this.catalog}`;
     } else {
       this.cacheKey = options?.cacheKey ?? "";
+    }
+  }
+
+  private async fetchCatalog(): Promise<SourceProviders> {
+    if (typeof this.catalog === "object") {
+      return Promise.resolve(this.catalog);
+    }
+
+    switch (this.catalog) {
+      case "auto":
+        return fetchOpenrouter({ fetch: this.fetchImpl });
+      case "openrouter":
+        return fetchOpenrouter({ fetch: this.fetchImpl });
+      case "models.dev":
+        return fetchModelsDev({ fetch: this.fetchImpl });
+      case "vercel":
+        return fetchVercel({ fetch: this.fetchImpl });
+      // TODO implement netlify AI Gateway
+      // case "netlify":
+      //   catalog = [];
+      //   break;
+      default:
+        throw new TokenlensError.InvalidCatalog(this.catalog);
     }
   }
 
@@ -52,25 +77,11 @@ export class Tokenlens {
     if (cached && cached.expiresAt > now) return cached.value;
 
     let catalog: SourceProviders;
-    switch (this.catalog) {
-      case "auto":
-        catalog = await fetchOpenrouter();
-        break;
-      case "openrouter":
-        catalog = await fetchOpenrouter();
-        break;
-      case "models.dev":
-        catalog = await fetchModelsDev();
-        break;
-      case "vercel":
-        catalog = await fetchVercel();
-        break;
-      // TODO implement netlify AI Gateway
-      // case "netlify":
-      //   catalog = [];
-      //   break;
-      default:
-        throw new TokenlensError.InvalidCatalog(this.catalog);
+    try {
+      catalog = await this.fetchCatalog();
+    } catch (error) {
+      if (cached) return cached.value;
+      throw error;
     }
 
     const entry = { value: catalog, expiresAt: now + jitter(this.ttlMs) };
@@ -84,27 +95,17 @@ export class Tokenlens {
     }
 
     const now = Date.now();
+    const cached = await this.cache.get(this.cacheKey);
     if (!force) {
-      const cached = await this.cache.get(this.cacheKey);
       if (cached && cached.expiresAt > now) return cached.value;
     }
 
     let catalog: SourceProviders;
-    switch (this.catalog) {
-      case "auto":
-        catalog = await fetchOpenrouter();
-        break;
-      case "openrouter":
-        catalog = await fetchOpenrouter();
-        break;
-      case "models.dev":
-        catalog = await fetchModelsDev();
-        break;
-      case "vercel":
-        catalog = await fetchVercel();
-        break;
-      default:
-        throw new TokenlensError.InvalidCatalog(this.catalog);
+    try {
+      catalog = await this.fetchCatalog();
+    } catch (error) {
+      if (cached) return cached.value;
+      throw error;
     }
 
     const entry = { value: catalog, expiresAt: now + jitter(this.ttlMs) };

--- a/packages/tokenlens/src/types.ts
+++ b/packages/tokenlens/src/types.ts
@@ -1,16 +1,5 @@
 import type { SourceProviders } from "@tokenlens/core";
 
-export type FetchLike = (
-  input: string,
-  init?: { signal?: unknown } & Record<string, unknown>,
-) => Promise<{
-  ok: boolean;
-  status: number;
-  statusText: string;
-  json(): Promise<unknown>;
-  text(): Promise<string>;
-}>;
-
 export const GATEWAY_IDS = [
   "auto",
   "openrouter",
@@ -22,8 +11,6 @@ export type GatewayId = (typeof GATEWAY_IDS)[number];
 
 export type CacheEntry = { value: SourceProviders; expiresAt: number };
 
-export type SourceLoader = (fetchImpl: FetchLike) => Promise<SourceProviders>;
-
 export interface CacheAdapter {
   get(key: string): Promise<CacheEntry | undefined> | CacheEntry | undefined;
   set(key: string, entry: CacheEntry): Promise<void> | void;
@@ -33,7 +20,7 @@ export interface CacheAdapter {
 export type TokenlensOptions = {
   catalog?: GatewayId | SourceProviders;
   ttlMs?: number;
-  fetch?: FetchLike;
+  fetch?: typeof globalThis.fetch;
   cache?: CacheAdapter;
   cacheKey?: string;
 };

--- a/packages/tokenlens/tests/tokenlens.test.ts
+++ b/packages/tokenlens/tests/tokenlens.test.ts
@@ -75,6 +75,22 @@ describe("Tokenlens - Catalog Loading", () => {
     expect(fetchOpenrouterSpy).toHaveBeenCalled();
   });
 
+  it("passes custom fetch to the catalog fetcher", async () => {
+    const mockCatalog = createOpenrouterProvidersFixture();
+    const fetchImpl = vi.fn<typeof globalThis.fetch>();
+    fetchOpenrouterSpy.mockResolvedValue(mockCatalog);
+
+    const client = new Tokenlens({
+      catalog: "openrouter",
+      cacheKey: "test-custom-fetch",
+      fetch: fetchImpl,
+    });
+
+    await client.getModelData({ modelId: "openai/gpt-4o" });
+
+    expect(fetchOpenrouterSpy).toHaveBeenCalledWith({ fetch: fetchImpl });
+  });
+
   it("uses models.dev catalog", async () => {
     const mockCatalog = createModelsDevProvidersFixture();
     fetchModelsDevSpy.mockResolvedValue(mockCatalog);
@@ -218,6 +234,30 @@ describe("Tokenlens - Caching", () => {
     await client.getModelData({ modelId: "openai/gpt-4o" });
 
     expect(fetchOpenrouterSpy).toHaveBeenCalledTimes(2);
+  });
+
+  it("falls back to stale cache when fetching a fresh catalog fails", async () => {
+    const staleCatalog = createOpenrouterProvidersFixture();
+    const cache: CacheAdapter = {
+      get: vi.fn(() => ({
+        value: staleCatalog,
+        expiresAt: Date.now() - 1,
+      })),
+      set: vi.fn(),
+    };
+    fetchOpenrouterSpy.mockRejectedValue(new Error("network failed"));
+
+    const client = new Tokenlens({
+      catalog: "openrouter",
+      cache,
+      cacheKey: "test-stale-fallback",
+    });
+
+    const modelData = await client.getModelData({ modelId: "openai/gpt-4o" });
+
+    expect(modelData?.id).toBe("openai/gpt-4o");
+    expect(fetchOpenrouterSpy).toHaveBeenCalledTimes(1);
+    expect(cache.set).not.toHaveBeenCalled();
   });
 });
 
@@ -508,13 +548,11 @@ describe("Tokenlens.getContextLimits()", () => {
 
 describe("Tokenlens.estimateCostUSD()", () => {
   let fetchOpenrouterSpy: Mock;
-  let fetchModelsDevSpy: Mock;
 
   beforeEach(async () => {
     vi.clearAllMocks();
     const fetchModule = await import("@tokenlens/fetch");
     fetchOpenrouterSpy = vi.spyOn(fetchModule, "fetchOpenrouter") as Mock;
-    fetchModelsDevSpy = vi.spyOn(fetchModule, "fetchModelsDev") as Mock;
   });
 
   afterEach(() => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -256,6 +256,9 @@ importers:
         specifier: workspace:*
         version: link:../../packages/tokenlens
     devDependencies:
+      '@types/node':
+        specifier: ^24.5.2
+        version: 24.6.2
       tsx:
         specifier: ^4.20.5
         version: 4.20.5
@@ -375,6 +378,9 @@ importers:
         specifier: workspace:*
         version: link:../tokenizer
     devDependencies:
+      '@types/node':
+        specifier: ^24.5.2
+        version: 24.6.2
       typescript:
         specifier: ^5.9.3
         version: 5.9.3


### PR DESCRIPTION
## Summary
- wire Tokenlens `fetch` option through to @tokenlens/fetch using `typeof globalThis.fetch`
- return stale cached catalogs when fresh catalog fetches fail
- add fetch injection and stale-cache regression tests
- add example typecheck scripts, fix broken examples, and run example typechecks in CI

## Validation
- pnpm install
- pnpm run format
- pnpm exec biome lint --reporter=summary packages examples .github/workflows/ci.yml
- pnpm exec biome lint examples/vercel-ai-sdk/src/index.ts examples/openai-sdk/src/index.ts packages/tokenlens/tests/tokenlens.test.ts packages/fetch/tests/fetch.spec.ts packages/tokenlens/src/client.ts packages/tokenlens/src/types.ts .github/workflows/ci.yml
- pnpm --filter @tokenlens/fetch run test:run
- pnpm --filter tokenlens run test:run
- pnpm turbo run typecheck --filter=./examples/*
- pnpm run typecheck
- pnpm run build
- pnpm run test:run

Note: `pnpm run format` still exits successfully while reporting existing v2 Biome warnings outside this follow-up scope.