### PR TITLE
Fix catalog overrides for v2

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ const tokenlens = new Tokenlens(options?: TokenlensOptions);
 
 **Options:**
 - `catalog`: `"auto" | "openrouter" | "models.dev" | "vercel"` or custom `SourceProviders` object (default: `"openrouter"`; `"auto"` is an alias for the same OpenRouter gateway)
+- `overrides`: Custom `SourceProviders` object merged over the base catalog. Use this for local price or limit corrections while preserving hosted metadata.
 - `ttlMs`: Cache TTL in milliseconds (default: 24 hours)
 - `cache`: Custom cache adapter with `{ get(key), set(key, entry), delete?(key) }` methods where `entry` is `{ value: SourceProviders; expiresAt: number }` (default: in-memory cache)
 - `cacheKey`: Custom cache key for the catalog (default: `tokenlens:v2:{catalog}`)
@@ -253,6 +254,7 @@ const customCatalog = {
     models: {
       "gpt-custom": {
         id: "gpt-custom",
+        canonical_id: "gpt-custom",
         name: "Custom GPT",
         // ... model metadata
       }
@@ -262,6 +264,25 @@ const customCatalog = {
 
 const customTokenlens = new Tokenlens({ 
   catalog: customCatalog 
+});
+
+// Or patch prices/limits on top of a hosted catalog
+const pricedTokenlens = new Tokenlens({
+  catalog: "openrouter",
+  overrides: {
+    openai: {
+      id: "openai",
+      source: "package",
+      models: {
+        "openai/gpt-4o-mini": {
+          id: "openai/gpt-4o-mini",
+          canonical_id: "openai/gpt-4o-mini",
+          name: "GPT-4o Mini",
+          cost: { input: 1, output: 2 },
+        },
+      },
+    },
+  },
 });
 ```
 

--- a/apps/www/content/docs/custom-catalog.mdx
+++ b/apps/www/content/docs/custom-catalog.mdx
@@ -5,4 +5,55 @@ description: "How to use a custom catalog with Tokenlens"
 
 # Custom Catalog
 
-coming soon
+Use a custom catalog when you want Tokenlens to resolve models from data you own. Use overrides when you want to keep a hosted catalog as the base and patch only the parts that differ.
+
+## Fully custom catalog
+
+```ts
+import { createTokenlens } from "tokenlens";
+import type { SourceProviders } from "tokenlens";
+
+const catalog: SourceProviders = {
+  internal: {
+    id: "internal",
+    source: "package",
+    models: {
+      "internal/chat": {
+        id: "internal/chat",
+        canonical_id: "internal/chat",
+        name: "Internal Chat",
+        cost: { input: 1, output: 2 },
+        limit: { context: 128_000 },
+      },
+    },
+  },
+};
+
+const tokenlens = createTokenlens({ catalog });
+```
+
+Passing an object as `catalog` disables hosted fetching. Tokenlens uses that object directly.
+
+## Override hosted metadata
+
+```ts
+const tokenlens = createTokenlens({
+  catalog: "openrouter",
+  overrides: {
+    openai: {
+      id: "openai",
+      source: "package",
+      models: {
+        "openai/gpt-4o-mini": {
+          id: "openai/gpt-4o-mini",
+          canonical_id: "openai/gpt-4o-mini",
+          name: "GPT-4o Mini",
+          cost: { input: 1, output: 2 },
+        },
+      },
+    },
+  },
+});
+```
+
+Override fields win over the base catalog. Nested `cost` and `limit` objects are merged, so omitted fields keep their hosted values.

--- a/apps/www/content/docs/getting-started.mdx
+++ b/apps/www/content/docs/getting-started.mdx
@@ -71,6 +71,7 @@ const fixtureCatalog: SourceProviders = {
     models: {
       "demo/chat": {
         id: "demo/chat",
+        canonical_id: "demo/chat",
         name: "Chat Demo",
         cost: { input: 1, output: 1 },
         limit: { context: 128_000, output: 4_096 },
@@ -82,6 +83,26 @@ const fixtureCatalog: SourceProviders = {
 const fixtureTokenlens = createTokenlens({
   catalog: fixtureCatalog,
   ttlMs: 0, // always reload
+});
+
+const priceOverrides: SourceProviders = {
+  demo: {
+    id: "demo",
+    source: "package",
+    models: {
+      "demo/chat": {
+        id: "demo/chat",
+        canonical_id: "demo/chat",
+        name: "Chat Demo",
+        cost: { input: 2 },
+      },
+    },
+  },
+};
+
+const tokenlensWithOverrides = createTokenlens({
+  catalog: "openrouter",
+  overrides: priceOverrides,
 });
 ```
 
@@ -97,6 +118,7 @@ const fixtureTokenlens = createTokenlens({
 | Default catalog and minimal setup                 | Call the top-level helpers (`computeCostUSD`, `getModelData`, `getContextLimits`).  |
 | Specific gateway or custom TTL/cache              | Create your own instance via `createTokenlens` and reuse it within your app.        |
 | Fixture or offline catalogs                       | Pass a `SourceProviders` object via `catalog` when creating the instance.           |
+| Custom prices or local model corrections          | Use `overrides` with a hosted or custom base catalog.                               |
 
 ## 5. TypeScript types
 

--- a/apps/www/content/docs/glossary.mdx
+++ b/apps/www/content/docs/glossary.mdx
@@ -47,11 +47,11 @@ This file defines canonical terminology used across the TokenLens v2 codebase an
 
 ## models.dev
 - External dataset consumed via `https://models.dev/api.json`.
-- In v2 we ingest it into `packages/models/src/modelsdev/`.
+- In v2 Tokenlens can fetch it live with the `"models.dev"` catalog.
 
 ## OpenRouter
 - External dataset consumed via `https://openrouter.ai/api/v1/models`.
-- In v2 we ingest it into `packages/models/src/openrouter/`.
+- In v2 Tokenlens can fetch it live with the `"openrouter"` catalog.
 
 ## Vercel AI Gateway
 - External dataset consumed via `https://ai-gateway.vercel.sh/v1/models`.
@@ -77,7 +77,8 @@ This file defines canonical terminology used across the TokenLens v2 codebase an
 
 ## Tokenlens (class)
 - Configurable client responsible for loading catalogs, caching provider metadata, and exposing helpers (`getModelData`, `computeCostUSD`, `getContextLimits`, `getContextHealth`, `estimateCostUSD`, `countTokens`).
-- Instances share a cache unless `cacheKey` is overridden.
+- Each instance uses its own in-memory cache by default.
+- Instances can share cached data by passing the same external cache adapter and `cacheKey`.
 
 ## createTokenlens
 - Convenience factory that instantiates `Tokenlens` with sensible defaults (OpenRouter catalog when none provided; `{ catalog: "auto" }` is equivalent to the same OpenRouter gateway).

--- a/apps/www/content/docs/overview.mdx
+++ b/apps/www/content/docs/overview.mdx
@@ -25,7 +25,7 @@ Tokenlens provides provider-aware model metadata and usage utilities for AI appl
 A `Tokenlens` instance encapsulates:
 - The **catalog** to load (`"auto"` – alias for OpenRouter, `"openrouter"`, `"models.dev"`, `"vercel"`, or a custom `SourceProviders` object).
 - Cache behaviour (`ttlMs`, `cache`, and `cacheKey`) that controls how long a loaded catalog is reused.
-- Optional wiring such as a custom cache adapter suited to your runtime.
+- Optional `overrides` for local prices, limits, or fixture providers that should win over the base catalog.
 
 The instance exposes helper methods that all operate on the same cached catalog:
 - `getModelData({ modelId, provider? })`
@@ -41,7 +41,7 @@ Tokenlens ships with gateway identifiers that point at hosted catalogs:
 - `"models.dev"` – curated dataset derived from models.dev.
 - `"vercel"` – Vercel AI Gateway models endpoint.
 
-Pass one of these identifiers via `catalog` to switch gateways, or supply your own `SourceProviders` object to run entirely on local fixture data (useful for tests and offline tooling).
+Pass one of these identifiers via `catalog` to switch gateways, or supply your own `SourceProviders` object to run entirely on local fixture data (useful for tests and offline tooling). Use `overrides` when you want hosted metadata plus local price or limit corrections.
 
 ### Caching
 Tokenlens caches provider metadata via an in-memory adapter (`MemoryCache`) by default. Features:
@@ -52,7 +52,7 @@ Tokenlens caches provider metadata via an in-memory adapter (`MemoryCache`) by d
 ### Standalone helpers
 The root module also exports `computeCostUSD`, `getModelData`, `getContextLimits`, `getContextHealth`, `countTokens`, and `estimateCostUSD`. The first call to any helper lazily creates a shared `Tokenlens` instance with default options (`catalog: "auto"`—the OpenRouter gateway—and an in-memory cache). Use the `gateway` option (for example, `{ gateway: "models.dev" }`) or instantiate via `createTokenlens()` when you need a different catalog.
 
-When you require custom configuration (specific gateway, custom cache, fixture catalogs), instantiate an explicit Tokenlens client via `createTokenlens` and reuse it within your application.
+When you require custom configuration (specific gateway, custom cache, fixture catalogs, or local overrides), instantiate an explicit Tokenlens client via `createTokenlens` and reuse it within your application.
 
 ## Architecture Diagram
 

--- a/apps/www/content/docs/package-setup-comparison.mdx
+++ b/apps/www/content/docs/package-setup-comparison.mdx
@@ -12,9 +12,9 @@ Reference: Zod repository (`https://github.com/colinhacks/zod`).
 ## Snapshot of our current setup
 
 - **Monorepo**: pnpm workspaces, Turborepo, packages under `packages/*`, apps under `apps/*`.
-- **CI**: Lint (Biome), Build (turbo), Test (vitest) on Node 20; weekly models.dev sync workflow.
+- **CI**: Lint (Biome), Build (turbo), Test (vitest), and example typechecks on Node 20.
 - **Formatting/Lint**: Biome configured; lefthook pre-commit runs formatting.
-- **Publishing**: `tokenlens` published; scoped packages `@tokenlens/core` and `@tokenlens/models` exist but lack full publish metadata.
+- **Publishing**: `tokenlens` published; scoped packages such as `@tokenlens/core`, `@tokenlens/fetch`, `@tokenlens/helpers`, and `@tokenlens/tokenizer` exist but need consistent publish metadata.
 - **Module format**: ESM with minimal `exports` fields.
 - **Testing**: Vitest in `tokenlens`; no coverage thresholds; no type-level API tests.
 
@@ -63,7 +63,7 @@ Reference: Zod repository (`https://github.com/colinhacks/zod`).
   - Document and pin `packageManager` at root and enforce via CI
 
 - **Package publishing hygiene**
-  - Add `publishConfig.access: public` for scoped packages (`@tokenlens/core`, `@tokenlens/models`)
+  - Add `publishConfig.access: public` for scoped packages.
   - Fill package metadata (`repository`, `homepage`, `bugs`, `license`, `funding`) for all packages
   - Include `LICENSE` and `README` in published `files` array for all packages
 
@@ -97,7 +97,6 @@ Reference: Zod repository (`https://github.com/colinhacks/zod`).
 ## References
 
 - Zod repository: [`https://github.com/colinhacks/zod`](https://github.com/colinhacks/zod)
-
 
 
 

--- a/apps/www/content/docs/sources-and-caching.mdx
+++ b/apps/www/content/docs/sources-and-caching.mdx
@@ -18,7 +18,7 @@ Pass one of the supported identifiers to `createTokenlens({ catalog })` or the c
 
 Instance helpers cache the loaded catalog, so repeated method calls stay fast as long as the data remains fresh.
 
-### Per-call overrides
+### Per-call gateway selection
 
 The module-level helpers (`getModelData`, `computeCostUSD`, etc.) accept an optional `gateway` property. This lets you reuse the shared helper instance while forcing a specific catalog on a single call:
 
@@ -46,6 +46,7 @@ const fixtureCatalog: SourceProviders = {
     models: {
       "demo/chat": {
         id: "demo/chat",
+        canonical_id: "demo/chat",
         name: "Chat Demo",
         cost: { input: 1, output: 1 },
         limit: { context: 128_000 },
@@ -61,6 +62,37 @@ const tokenlens = createTokenlens({
 ```
 
 Passing a `SourceProviders` object bypasses remote fetching entirely—Tokenlens uses the structure you provide as-is.
+
+## Catalog overrides
+
+Use `overrides` when you want a hosted catalog as the base but need local corrections, such as custom pricing, private model limits, or provider metadata that has not landed upstream yet. Override fields win over the base catalog; nested `cost` and `limit` objects are merged so you only need to provide the fields you want to change.
+
+```ts
+import { createTokenlens } from "tokenlens";
+import type { SourceProviders } from "tokenlens";
+
+const priceOverrides: SourceProviders = {
+  openai: {
+    id: "openai",
+    source: "package",
+    models: {
+      "openai/gpt-4o-mini": {
+        id: "openai/gpt-4o-mini",
+        canonical_id: "openai/gpt-4o-mini",
+        name: "GPT-4o Mini",
+        cost: { input: 1, output: 2 },
+      },
+    },
+  },
+};
+
+const tokenlens = createTokenlens({
+  catalog: "openrouter",
+  overrides: priceOverrides,
+});
+```
+
+`source: "package"` is useful provenance for local or package-provided data. It is not a value for the `catalog` option.
 
 ## Caching
 
@@ -129,6 +161,7 @@ These hooks are useful when you know provider metadata has changed and you want 
 ## Summary
 
 - Pick a built-in `catalog` (`"auto"`, `"openrouter"`, `"models.dev"`, `"vercel"`) or supply your own `SourceProviders`.
+- Use `overrides` for local price/limit corrections on top of a hosted catalog.
 - Override `gateway` per call when using the shared helpers.
 - Configure caching behaviour with `ttlMs`, `cache`, and `cacheKey`.
 - Use `refresh()` / `invalidate()` for manual control when needed.

--- a/apps/www/content/docs/testing.mdx
+++ b/apps/www/content/docs/testing.mdx
@@ -24,6 +24,8 @@ const testProviders: SourceProviders = {
     models: {
       "openai/gpt-5": {
         id: "openai/gpt-5",
+        canonical_id: "openai/gpt-5",
+        name: "GPT-5",
         limit: { context: 200_000, output: 8_192 },
         cost: { input: 30, output: 60 },
       },

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -41,7 +41,7 @@ console.log(m?.id); // 'openai:gpt-4o'
 ```
 
 See also
-- `@tokenlens/models` for a prebuilt models catalog.
+- `@tokenlens/fetch` for hosted catalog fetchers.
 - `@tokenlens/helpers` for context/cost utilities layered on top.
 
 License

--- a/packages/fetch/README.md
+++ b/packages/fetch/README.md
@@ -52,14 +52,12 @@ const providers = combine([
 ```
 
 API
-- `fetchModelsDev(options?: { provider?: string; model?: string; fetch?: FetchLike })`
+- `fetchModelsDev(options?: { provider?: string; model?: string; fetch?: typeof globalThis.fetch })`
   - Fetches the public models.dev JSON, normalizes provider metadata and models, and optionally filters.
-- `fetchOpenrouter(options?: { provider?: string; model?: string; fetch?: FetchLike })`
+- `fetchOpenrouter(options?: { provider?: string; model?: string; fetch?: typeof globalThis.fetch })`
   - Calls `https://openrouter.ai/api/v1/models`, groups models by namespace, and keeps pricing/limit details.
-- `fetchVercel(options?: { provider?: string; model?: string; fetch?: FetchLike })`
+- `fetchVercel(options?: { provider?: string; model?: string; fetch?: typeof globalThis.fetch })`
   - Loads `https://ai-gateway.vercel.sh/v1/models`, groups models by upstream provider, and converts pricing.
-- `FetchLike`
-  - Minimal fetch contract accepted by both functions. Useful when wiring Node, Deno, Cloudflare Workers, etc.
 
 DTO exports
 ```ts

--- a/packages/tokenlens/README.md
+++ b/packages/tokenlens/README.md
@@ -74,6 +74,7 @@ const tokenlens = new Tokenlens(options?: TokenlensOptions);
 
 **Options:**
 - `catalog`: `"auto" | "openrouter" | "models.dev" | "vercel"` or custom `SourceProviders` object (default: `"openrouter"`; `"auto"` is an alias for the same OpenRouter gateway)
+- `overrides`: Custom `SourceProviders` object merged over the base catalog. Use this for local price or limit corrections while preserving hosted metadata.
 - `ttlMs`: Cache TTL in milliseconds (default: 24 hours)
 - `cache`: Custom cache adapter with `{ get(key), set(key, entry), delete?(key) }` methods where `entry` is `{ value: SourceProviders; expiresAt: number }` (default: in-memory cache)
 - `cacheKey`: Custom cache key for the catalog (default: `tokenlens:v2:{catalog}`)
@@ -253,6 +254,7 @@ const customCatalog = {
     models: {
       "gpt-custom": {
         id: "gpt-custom",
+        canonical_id: "gpt-custom",
         name: "Custom GPT",
         // ... model metadata
       }
@@ -262,6 +264,25 @@ const customCatalog = {
 
 const customTokenlens = new Tokenlens({ 
   catalog: customCatalog 
+});
+
+// Or patch prices/limits on top of a hosted catalog
+const pricedTokenlens = new Tokenlens({
+  catalog: "openrouter",
+  overrides: {
+    openai: {
+      id: "openai",
+      source: "package",
+      models: {
+        "openai/gpt-4o-mini": {
+          id: "openai/gpt-4o-mini",
+          canonical_id: "openai/gpt-4o-mini",
+          name: "GPT-4o Mini",
+          cost: { input: 1, output: 2 },
+        },
+      },
+    },
+  },
 });
 ```
 
@@ -322,6 +343,7 @@ const testCatalog = {
     models: {
       "test-model": {
         id: "test-model",
+        canonical_id: "test-model",
         name: "Test Model",
         limit: { context: 4096, output: 2048 },
         cost: { input: 1, output: 2 },

--- a/packages/tokenlens/src/client.ts
+++ b/packages/tokenlens/src/client.ts
@@ -24,6 +24,7 @@ export type ModelDetails = SourceModel | undefined;
 
 export class Tokenlens {
   private readonly catalog: GatewayId | SourceProviders;
+  private readonly overrides: SourceProviders | undefined;
   private readonly ttlMs: number;
   private readonly cache: CacheAdapter;
   private readonly cacheKey: string;
@@ -32,6 +33,7 @@ export class Tokenlens {
   constructor(options?: TokenlensOptions) {
     // use automode as default
     this.catalog = options?.catalog ?? GATEWAY_IDS[1];
+    this.overrides = options?.overrides;
     this.ttlMs = options?.ttlMs ?? 24 * 60 * 60 * 1000;
     this.cache = options?.cache ?? new MemoryCache();
     this.fetchImpl = options?.fetch ?? globalThis.fetch;
@@ -69,48 +71,52 @@ export class Tokenlens {
 
   private async loadCatalog(): Promise<SourceProviders> {
     if (typeof this.catalog === "object") {
-      return Promise.resolve(this.catalog);
+      return Promise.resolve(mergeCatalogs(this.catalog, this.overrides));
     }
 
     const now = Date.now();
     const cached = await this.cache.get(this.cacheKey);
-    if (cached && cached.expiresAt > now) return cached.value;
+    if (cached && cached.expiresAt > now) {
+      return mergeCatalogs(cached.value, this.overrides);
+    }
 
     let catalog: SourceProviders;
     try {
       catalog = await this.fetchCatalog();
     } catch (error) {
-      if (cached) return cached.value;
+      if (cached) return mergeCatalogs(cached.value, this.overrides);
       throw error;
     }
 
     const entry = { value: catalog, expiresAt: now + jitter(this.ttlMs) };
     await this.cache.set(this.cacheKey, entry);
-    return catalog;
+    return mergeCatalogs(catalog, this.overrides);
   }
 
   async refresh(force?: boolean): Promise<SourceProviders> {
     if (typeof this.catalog === "object") {
-      return Promise.resolve(this.catalog);
+      return Promise.resolve(mergeCatalogs(this.catalog, this.overrides));
     }
 
     const now = Date.now();
     const cached = await this.cache.get(this.cacheKey);
     if (!force) {
-      if (cached && cached.expiresAt > now) return cached.value;
+      if (cached && cached.expiresAt > now) {
+        return mergeCatalogs(cached.value, this.overrides);
+      }
     }
 
     let catalog: SourceProviders;
     try {
       catalog = await this.fetchCatalog();
     } catch (error) {
-      if (cached) return cached.value;
+      if (cached) return mergeCatalogs(cached.value, this.overrides);
       throw error;
     }
 
     const entry = { value: catalog, expiresAt: now + jitter(this.ttlMs) };
     await this.cache.set(this.cacheKey, entry);
-    return catalog;
+    return mergeCatalogs(catalog, this.overrides);
   }
 
   async invalidate(): Promise<void> {
@@ -382,4 +388,73 @@ export class Tokenlens {
     }
     return getContextHealth({ model: resolved.model, usage: args.usage });
   }
+}
+
+function mergeCatalogs(
+  base: SourceProviders,
+  overrides?: SourceProviders,
+): SourceProviders {
+  if (!overrides) return base;
+
+  const merged: SourceProviders = {};
+  for (const [providerId, provider] of Object.entries(base)) {
+    merged[providerId] = {
+      ...provider,
+      models: { ...(provider.models ?? {}) },
+      ...(provider.extras ? { extras: { ...provider.extras } } : {}),
+    };
+  }
+
+  for (const [providerId, providerOverride] of Object.entries(overrides)) {
+    const existingProvider = merged[providerId];
+    if (!existingProvider) {
+      merged[providerId] = {
+        ...providerOverride,
+        models: { ...(providerOverride.models ?? {}) },
+        ...(providerOverride.extras
+          ? { extras: { ...providerOverride.extras } }
+          : {}),
+      };
+      continue;
+    }
+
+    const nextModels = { ...(existingProvider.models ?? {}) };
+    for (const [modelId, modelOverride] of Object.entries(
+      providerOverride.models ?? {},
+    )) {
+      const existingModel = nextModels[modelId];
+      if (!existingModel) {
+        nextModels[modelId] = modelOverride;
+        continue;
+      }
+
+      const mergedModel = { ...existingModel, ...modelOverride };
+      if (existingModel.cost || modelOverride.cost) {
+        mergedModel.cost = { ...existingModel.cost, ...modelOverride.cost };
+      }
+      if (existingModel.limit || modelOverride.limit) {
+        mergedModel.limit = { ...existingModel.limit, ...modelOverride.limit };
+      }
+      nextModels[modelId] = mergedModel;
+    }
+
+    const mergedProvider = {
+      ...existingProvider,
+      ...providerOverride,
+      models: nextModels,
+    };
+    const env = providerOverride.env ?? existingProvider.env;
+    if (env) {
+      mergedProvider.env = env;
+    }
+    if (existingProvider.extras || providerOverride.extras) {
+      mergedProvider.extras = {
+        ...existingProvider.extras,
+        ...providerOverride.extras,
+      };
+    }
+    merged[providerId] = mergedProvider;
+  }
+
+  return merged;
 }

--- a/packages/tokenlens/src/types.ts
+++ b/packages/tokenlens/src/types.ts
@@ -5,7 +5,6 @@ export const GATEWAY_IDS = [
   "openrouter",
   "models.dev",
   "vercel",
-  "package",
 ] as const;
 export type GatewayId = (typeof GATEWAY_IDS)[number];
 
@@ -19,6 +18,7 @@ export interface CacheAdapter {
 
 export type TokenlensOptions = {
   catalog?: GatewayId | SourceProviders;
+  overrides?: SourceProviders;
   ttlMs?: number;
   fetch?: typeof globalThis.fetch;
   cache?: CacheAdapter;

--- a/packages/tokenlens/tests/tokenlens.test.ts
+++ b/packages/tokenlens/tests/tokenlens.test.ts
@@ -1,4 +1,4 @@
-import { TokenlensError } from "@tokenlens/core";
+import { type SourceProviders, TokenlensError } from "@tokenlens/core";
 import { compactJson } from "@tokenlens/helpers";
 import type { Mock } from "vitest";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -12,6 +12,7 @@ import {
   createTokenlens,
   setSharedTokenlens,
 } from "../src/index.js";
+import type { CacheAdapter, CacheEntry } from "../src/types.js";
 import {
   createModelsDevProvidersFixture,
   createOpenrouterProvidersFixture,
@@ -135,6 +136,133 @@ describe("Tokenlens - Catalog Loading", () => {
 
     expect(modelData?.id).toBe("openai/gpt-4o");
     expect(fetchModelsDevSpy).not.toHaveBeenCalled();
+    expect(fetchOpenrouterSpy).not.toHaveBeenCalled();
+  });
+
+  it("applies custom overrides on top of a built-in catalog", async () => {
+    const mockCatalog = createOpenrouterProvidersFixture();
+    const overrides: SourceProviders = {
+      openai: {
+        id: "openai",
+        source: "package",
+        models: {
+          "openai/gpt-4o": {
+            id: "openai/gpt-4o",
+            canonical_id: "openai/gpt-4o",
+            name: "GPT-4o",
+            cost: { input: 3, cache_write: 9 },
+            limit: { output: 16_384 },
+          },
+        },
+      },
+    };
+    fetchOpenrouterSpy.mockResolvedValue(mockCatalog);
+
+    const client = new Tokenlens({
+      catalog: "openrouter",
+      overrides,
+      cacheKey: "test-overrides",
+    });
+
+    const modelData = await client.getModelData({ modelId: "openai/gpt-4o" });
+    const costs = await client.computeCostUSD({
+      modelId: "openai/gpt-4o",
+      usage: { input_tokens: 1_000, output_tokens: 1_000 },
+    });
+
+    expect(modelData?.limit?.context).toBe(128_000);
+    expect(modelData?.limit?.output).toBe(16_384);
+    expect(modelData?.cost?.input).toBe(3);
+    expect(modelData?.cost?.output).toBe(60);
+    expect(modelData?.cost?.cache_write).toBe(9);
+    expect(costs.inputTokenCostUSD).toBeCloseTo(0.003, 6);
+    expect(costs.outputTokenCostUSD).toBeCloseTo(0.06, 6);
+  });
+
+  it("keeps per-instance overrides separate when sharing a cache", async () => {
+    const mockCatalog = createOpenrouterProvidersFixture();
+    const cacheStore = new Map<string, CacheEntry>();
+    const cache: CacheAdapter = {
+      get: vi.fn((key) => cacheStore.get(key)),
+      set: vi.fn((key, entry) => {
+        cacheStore.set(key, entry);
+      }),
+    };
+    const makeOverrides = (inputCost: number): SourceProviders => ({
+      openai: {
+        id: "openai",
+        source: "package",
+        models: {
+          "openai/gpt-4o": {
+            id: "openai/gpt-4o",
+            canonical_id: "openai/gpt-4o",
+            name: "GPT-4o",
+            cost: { input: inputCost },
+          },
+        },
+      },
+    });
+    fetchOpenrouterSpy.mockResolvedValue(mockCatalog);
+
+    const firstClient = new Tokenlens({
+      catalog: "openrouter",
+      overrides: makeOverrides(3),
+      cache,
+      cacheKey: "test-shared-overrides",
+    });
+    const secondClient = new Tokenlens({
+      catalog: "openrouter",
+      overrides: makeOverrides(7),
+      cache,
+      cacheKey: "test-shared-overrides",
+    });
+
+    const firstCosts = await firstClient.computeCostUSD({
+      modelId: "openai/gpt-4o",
+      usage: { input_tokens: 1_000 },
+    });
+    const secondCosts = await secondClient.computeCostUSD({
+      modelId: "openai/gpt-4o",
+      usage: { input_tokens: 1_000 },
+    });
+
+    expect(firstCosts.inputTokenCostUSD).toBeCloseTo(0.003, 6);
+    expect(secondCosts.inputTokenCostUSD).toBeCloseTo(0.007, 6);
+    expect(fetchOpenrouterSpy).toHaveBeenCalledTimes(1);
+    expect(
+      cacheStore.get("test-shared-overrides")?.value.openai.models[
+        "openai/gpt-4o"
+      ].cost?.input,
+    ).toBe(30);
+  });
+
+  it("applies custom overrides on top of a custom catalog object", async () => {
+    const customCatalog = createOpenrouterProvidersFixture();
+    const overrides: SourceProviders = {
+      openai: {
+        id: "openai",
+        source: "package",
+        models: {
+          "openai/gpt-4o": {
+            id: "openai/gpt-4o",
+            canonical_id: "openai/gpt-4o",
+            name: "GPT-4o",
+            cost: { input: 4 },
+          },
+        },
+      },
+    };
+
+    const client = new Tokenlens({
+      catalog: customCatalog,
+      overrides,
+      cacheKey: "test-custom-overrides",
+    });
+
+    const modelData = await client.getModelData({ modelId: "openai/gpt-4o" });
+
+    expect(modelData?.cost?.input).toBe(4);
+    expect(modelData?.cost?.output).toBe(60);
     expect(fetchOpenrouterSpy).not.toHaveBeenCalled();
   });
 


### PR DESCRIPTION
## Summary
- remove `package` from the public gateway union and keep it only as source provenance
- add `overrides` for custom catalog price/limit corrections on top of hosted or custom catalogs
- cache raw hosted catalog data and apply overrides per instance, including shared cache paths
- update docs/readmes for custom catalogs, overrides, and stale package references

## Validation
- pnpm run format
- pnpm --filter tokenlens run test:run
- pnpm run typecheck
- pnpm exec biome lint --reporter=summary packages
- pnpm run build
- pnpm run test:run

Note: lint/format report the existing warning set, but exit successfully.