### PR TITLE
fix: resolve v2 stable readiness issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,8 +38,8 @@ import { Tokenlens } from "tokenlens";
 const tokenlens = new Tokenlens();
 
 // Get model metadata
-const model = await tokenlens.getModelData({ 
-  modelId: "openai/gpt-4o-mini" 
+const model = await tokenlens.getModelData({
+  modelId: "openai/gpt-4o-mini"
 });
 
 // Compute costs from usage
@@ -57,8 +57,8 @@ const costs = await tokenlens.computeCostUSD({
 console.log(`Total cost: $${costs.totalTokenCostUSD.toFixed(6)}`);
 
 // Get context limits
-const limits = await tokenlens.getContextLimits({ 
-  modelId: "openai/gpt-4o-mini" 
+const limits = await tokenlens.getContextLimits({
+  modelId: "openai/gpt-4o-mini"
 });
 
 console.log(`Context: ${limits?.context} tokens`);
@@ -226,9 +226,9 @@ TokenLens supports multiple model ID formats:
 await tokenlens.getModelData({ modelId: "openai/gpt-4o-mini" });
 
 // Separate provider parameter
-await tokenlens.getModelData({ 
-  modelId: "gpt-4o-mini", 
-  provider: "openai" 
+await tokenlens.getModelData({
+  modelId: "gpt-4o-mini",
+  provider: "openai"
 });
 
 // Model only (searches across providers, may be ambiguous)
@@ -243,8 +243,8 @@ await tokenlens.getModelData({ modelId: "gpt-4o-mini" });
 import { Tokenlens } from "tokenlens";
 
 // Use models.dev instead of OpenRouter
-const tokenlens = new Tokenlens({ 
-  catalog: "models.dev" 
+const tokenlens = new Tokenlens({
+  catalog: "models.dev"
 });
 
 // Or provide your own catalog
@@ -262,8 +262,8 @@ const customCatalog = {
   }
 };
 
-const customTokenlens = new Tokenlens({ 
-  catalog: customCatalog 
+const customTokenlens = new Tokenlens({
+  catalog: customCatalog
 });
 
 // Or patch prices/limits on top of a hosted catalog
@@ -352,8 +352,8 @@ const testCatalog = {
   }
 };
 
-const tokenlens = new Tokenlens({ 
-  catalog: testCatalog 
+const tokenlens = new Tokenlens({
+  catalog: testCatalog
 });
 ```
 

--- a/apps/www/content/docs/overview.mdx
+++ b/apps/www/content/docs/overview.mdx
@@ -3,9 +3,9 @@ title: "Tokenlens Overview"
 description: "What Tokenlens is, why it exists, and core concepts."
 ---
 
-> **⚠️ Experimental Docs:**  
-> These docs cover Tokenlens **v2**. For early access, install the alpha:  
->  
+> **⚠️ Experimental Docs:**
+> These docs cover Tokenlens **v2**. For early access, install the alpha:
+>
 > ```sh
 > npm i tokenlens@alpha
 > ```

--- a/apps/www/content/docs/sources-and-caching.mdx
+++ b/apps/www/content/docs/sources-and-caching.mdx
@@ -96,7 +96,7 @@ const tokenlens = createTokenlens({
 
 ## Caching
 
-Tokenlens caches the merged provider catalog to avoid repeated network calls. The default adapter is an in-memory `MemoryCache` with a 24h TTL.
+Tokenlens caches the raw provider catalog to avoid repeated network calls. Returned values include any per-instance `overrides`, which are applied after reading from the cache. The default adapter is an in-memory `MemoryCache` with a 24h TTL.
 
 ### Key options
 

--- a/examples/anthropic-sdk/README.md
+++ b/examples/anthropic-sdk/README.md
@@ -28,4 +28,3 @@ pnpm --filter anthopic-sdk start
 ```
 
 The script prints the Claude reply, raw Anthropic usage details, the cost estimate from `tokenlens`, and remaining context tokens relative to the model window.
-

--- a/examples/anthropic-sdk/env.example
+++ b/examples/anthropic-sdk/env.example
@@ -1,2 +1,1 @@
 ANTHROPIC_API_KEY="sk-your-anthropic-key"
-

--- a/examples/openai-sdk/README.md
+++ b/examples/openai-sdk/README.md
@@ -28,4 +28,3 @@ pnpm --filter openai-sdk start
 ```
 
 The script logs the model output, raw usage from OpenAI, the cost estimate computed by `tokenlens`, and remaining context tokens relative to the model limit.
-

--- a/examples/openai-sdk/env.example
+++ b/examples/openai-sdk/env.example
@@ -1,2 +1,1 @@
 OPENAI_API_KEY="sk-your-openai-key"
-

--- a/examples/vercel-ai-sdk/README.md
+++ b/examples/vercel-ai-sdk/README.md
@@ -28,4 +28,3 @@ pnpm --filter vercel-ai-sdk start
 ```
 
 On success the script prints the model response, raw usage from the AI SDK, the USD cost estimate from `tokenlens`, and remaining context tokens relative to the model limit.
-

--- a/examples/vercel-ai-sdk/env.example
+++ b/examples/vercel-ai-sdk/env.example
@@ -1,2 +1,1 @@
 AI_SDK_OPENAI_API_KEY="sk-your-openai-key"
-

--- a/packages/helpers/README.md
+++ b/packages/helpers/README.md
@@ -213,9 +213,9 @@ Use these helpers directly when you:
 - Are building custom tooling on top of TokenLens
 
 ```ts
-import { 
-  computeTokenCostsForModel, 
-  getContextHealth 
+import {
+  computeTokenCostsForModel,
+  getContextHealth
 } from "@tokenlens/helpers";
 import type { SourceModel } from "@tokenlens/core";
 

--- a/packages/tokenizer/README.md
+++ b/packages/tokenizer/README.md
@@ -37,7 +37,7 @@ import { countTokens } from "@tokenlens/tokenizer";
 await countTokens("gpt-4o", "Hello world");
 // => 2
 
-await countTokens("claude-sonnet-4-5", "Hello world");  
+await countTokens("claude-sonnet-4-5", "Hello world");
 // => 3
 
 await countTokens("gemini-2.5-pro", "Hello world");
@@ -64,7 +64,7 @@ await countTokens("future-model-xyz", "Hello world");
 Routes to correct tokenizer based on model name:
 - `gpt-*` or `openai/*` → OpenAI tiktoken (local)
 - `claude-*` or `anthropic/*` → Anthropic API
-- `gemini-*` or `google/*` → Google API  
+- `gemini-*` or `google/*` → Google API
 - Unknown → Falls back to GPT-5 tiktoken
 
 ## Supported Models

--- a/packages/tokenlens/README.md
+++ b/packages/tokenlens/README.md
@@ -38,8 +38,8 @@ import { Tokenlens } from "tokenlens";
 const tokenlens = new Tokenlens();
 
 // Get model metadata
-const model = await tokenlens.getModelData({ 
-  modelId: "openai/gpt-4o-mini" 
+const model = await tokenlens.getModelData({
+  modelId: "openai/gpt-4o-mini"
 });
 
 // Compute costs from usage
@@ -57,8 +57,8 @@ const costs = await tokenlens.computeCostUSD({
 console.log(`Total cost: $${costs.totalTokenCostUSD.toFixed(6)}`);
 
 // Get context limits
-const limits = await tokenlens.getContextLimits({ 
-  modelId: "openai/gpt-4o-mini" 
+const limits = await tokenlens.getContextLimits({
+  modelId: "openai/gpt-4o-mini"
 });
 
 console.log(`Context: ${limits?.context} tokens`);
@@ -226,9 +226,9 @@ TokenLens supports multiple model ID formats:
 await tokenlens.getModelData({ modelId: "openai/gpt-4o-mini" });
 
 // Separate provider parameter
-await tokenlens.getModelData({ 
-  modelId: "gpt-4o-mini", 
-  provider: "openai" 
+await tokenlens.getModelData({
+  modelId: "gpt-4o-mini",
+  provider: "openai"
 });
 
 // Model only (searches across providers, may be ambiguous)
@@ -243,8 +243,8 @@ await tokenlens.getModelData({ modelId: "gpt-4o-mini" });
 import { Tokenlens } from "tokenlens";
 
 // Use models.dev instead of OpenRouter
-const tokenlens = new Tokenlens({ 
-  catalog: "models.dev" 
+const tokenlens = new Tokenlens({
+  catalog: "models.dev"
 });
 
 // Or provide your own catalog
@@ -262,8 +262,8 @@ const customCatalog = {
   }
 };
 
-const customTokenlens = new Tokenlens({ 
-  catalog: customCatalog 
+const customTokenlens = new Tokenlens({
+  catalog: customCatalog
 });
 
 // Or patch prices/limits on top of a hosted catalog
@@ -352,8 +352,8 @@ const testCatalog = {
   }
 };
 
-const tokenlens = new Tokenlens({ 
-  catalog: testCatalog 
+const tokenlens = new Tokenlens({
+  catalog: testCatalog
 });
 ```
 

--- a/packages/vercel/src/middleware.test.ts
+++ b/packages/vercel/src/middleware.test.ts
@@ -1,5 +1,4 @@
 import { generateText } from "ai";
-import { MockLanguageModelV2 } from "ai/test";
 import type { Tokenlens } from "tokenlens";
 import { expect, test, vi } from "vitest";
 import {
@@ -33,17 +32,47 @@ const tokenlens: Pick<Tokenlens, "computeCostUSD"> = {
   computeCostUSD: computeCostUSDMock,
 };
 
-const mockModel = new MockLanguageModelV2({
+const createMockModel = (options?: {
+  provider?: string;
+  modelId?: string;
+}): Parameters<typeof withTokenlens>[0] => ({
+  specificationVersion: "v2",
+  provider: options?.provider ?? "mock-provider",
+  modelId: options?.modelId ?? "mock-model-id",
+  supportedUrls: {},
   doGenerate: async () => ({
     finishReason: "stop",
     usage: {
-      inputTokens: inputTokens,
-      outputTokens: outputTokens,
-      totalTokens: totalTokens,
+      inputTokens,
+      outputTokens,
+      totalTokens,
     },
     content: [{ type: "text", text: "Hello, world!" }],
     warnings: [],
   }),
+  doStream: async () => ({
+    stream: new ReadableStream({
+      start(controller) {
+        controller.enqueue({
+          type: "finish",
+          usage: {
+            inputTokens,
+            outputTokens,
+            totalTokens,
+          },
+          finishReason: "stop",
+        });
+        controller.close();
+      },
+    }),
+  }),
+});
+
+const mockModel = createMockModel();
+
+const gatewayModel = createMockModel({
+  provider: "gateway",
+  modelId: "openai/gpt-5",
 });
 
 const sampleCosts = {
@@ -105,8 +134,39 @@ test("wrapVercelLanguageModel", async () => {
   expect(computeCostUSDMock).toHaveBeenCalledTimes(1);
 });
 
+test("withTokenlens resolves gateway-prefixed model ids without forcing gateway provider", async () => {
+  computeCostUSDMock.mockClear();
+  computeCostUSDMock.mockImplementation(async ({ modelId, provider }) => {
+    expect(modelId).toBe("openai/gpt-5");
+    expect(provider).toBeUndefined();
+    return {
+      ...sampleCosts,
+      ratesUsed: {
+        inputPerMTokens: inputTokenCostUSD * 1_000_000,
+        outputPerMTokens: outputTokenCostUSD * 1_000_000,
+      },
+    };
+  });
+
+  const model = withTokenlens(gatewayModel, tokenlens);
+
+  await generateText({
+    model,
+    prompt: "Hello, how are you?",
+  });
+
+  expect(computeCostUSDMock).toHaveBeenCalledTimes(1);
+});
+
 test("withTokenlensV5 wraps AI SDK v5 models explicitly", async () => {
   computeCostUSDMock.mockClear();
+  computeCostUSDMock.mockImplementation(async () => ({
+    ...sampleCosts,
+    ratesUsed: {
+      inputPerMTokens: inputTokenCostUSD * 1_000_000,
+      outputPerMTokens: outputTokenCostUSD * 1_000_000,
+    },
+  }));
 
   const model = withTokenlensV5(mockModel, tokenlens);
 

--- a/packages/vercel/src/middleware.ts
+++ b/packages/vercel/src/middleware.ts
@@ -120,12 +120,18 @@ const computeCosts = async ({
   tokenlens: TokenlensClient;
   model: { modelId: string; provider: string };
   usage: unknown;
-}) =>
-  tokenlens.computeCostUSD({
+}) => {
+  const provider =
+    model.provider === "gateway" && model.modelId.includes("/")
+      ? undefined
+      : model.provider;
+
+  return tokenlens.computeCostUSD({
     modelId: model.modelId,
-    provider: model.provider,
+    ...(provider !== undefined ? { provider } : {}),
     usage: toTokenlensUsage(usage),
   });
+};
 
 /**
  * Middleware to add token costs to the usage.


### PR DESCRIPTION
## Summary
- omit the synthetic AI SDK Gateway provider when the model ID already carries the real provider prefix
- add a regression test for Gateway-prefixed model IDs and remove the brittle ai/test mock dependency from the Vercel middleware tests
- correct caching docs to describe raw catalog caching with per-instance overrides applied after cache reads
- clean whitespace issues caught by git diff --check

## Validation
- pnpm --filter @tokenlens/vercel run typecheck
- pnpm exec vitest run --config vitest.config.ts --project vercel
- pnpm run format
- pnpm exec biome lint --reporter=summary packages apps examples
- pnpm run build
- pnpm run typecheck
- pnpm run test:run
- git diff --check origin/main...HEAD

## Follow-up
- release-prep PR for replacing alpha package versions/install docs with stable v2 release metadata