### PR TITLE
chore: prepare v2 stable release metadata

### DIFF
--- a/apps/www/content/docs/overview.mdx
+++ b/apps/www/content/docs/overview.mdx
@@ -3,11 +3,10 @@ title: "Tokenlens Overview"
 description: "What Tokenlens is, why it exists, and core concepts."
 ---
 
-> **⚠️ Experimental Docs:**
-> These docs cover Tokenlens **v2**. For early access, install the alpha:
+> These docs cover Tokenlens **v2**. Install the stable v2 package:
 >
 > ```sh
-> npm i tokenlens@alpha
+> npm i tokenlens
 > ```
 
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tokenlens/core",
-  "version": "2.0.0-alpha.3",
+  "version": "2.0.0",
   "private": false,
   "description": "Core types and registry utilities for TokenLens (model metadata).",
   "type": "module",

--- a/packages/fetch/package.json
+++ b/packages/fetch/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tokenlens/fetch",
-  "version": "2.0.0-alpha.3",
+  "version": "2.0.0",
   "private": false,
   "description": "Typed client for models.dev to fetch model catalogs with friendly errors.",
   "type": "module",

--- a/packages/helpers/package.json
+++ b/packages/helpers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tokenlens/helpers",
-  "version": "2.0.0-alpha.3",
+  "version": "2.0.0",
   "private": false,
   "description": "Helpers for context windows, usage normalization, compaction, and cost estimation.",
   "type": "module",

--- a/packages/tokenizer/package.json
+++ b/packages/tokenizer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tokenlens/tokenizer",
-  "version": "2.0.0-alpha.3",
+  "version": "2.0.0",
   "private": false,
   "description": "Tokenizer utilities for Tokenlens.",
   "type": "module",

--- a/packages/tokenlens/package.json
+++ b/packages/tokenlens/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tokenlens",
-  "version": "2.0.0-alpha.3",
+  "version": "2.0.0",
   "description": "A lightweight registry of LLM model information, like name and context sizes, for building AI-powered apps.",
   "files": [
     "dist"

--- a/packages/vercel/package.json
+++ b/packages/vercel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tokenlens/vercel",
-  "version": "2.0.0-alpha.3",
+  "version": "2.0.0",
   "private": false,
   "description": "Tokenlens middleware helpers for the Vercel AI SDK.",
   "type": "module",


### PR DESCRIPTION
## Summary
- bump publishable Tokenlens packages from 2.0.0-alpha.3 to 2.0.0
- update the v2 docs overview install command from tokenlens@alpha to tokenlens

## Validation
- pnpm run format
- pnpm exec biome lint --reporter=summary packages apps examples
- pnpm run typecheck
- pnpm run build
- git diff --check origin/v2...HEAD

## Known dependency
- pnpm run test:run currently fails on v2 in @tokenlens/vercel before collecting tests with localStorage.getItem from msw; that runtime/test issue is fixed separately in #23. Merge this after #23 or rerun full tests after rebasing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated installation documentation to reference v2.0.0 stable, guiding users to install `tokenlens` instead of the experimental alpha package.

* **Chores**
  * Version bumped to 2.0.0 across all core packages including core, fetch, helpers, tokenizer, main package, and Vercel integration.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/xn1cklas/tokenlens/pull/24)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->