### PR TITLE
ci: validate apps on pull requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,8 +31,8 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
-      - name: Biome lint (packages only)
-        run: pnpm exec biome lint --reporter=summary packages
+      - name: Biome lint
+        run: pnpm exec biome lint --reporter=summary packages apps examples
 
   build:
     name: Build
@@ -64,10 +64,13 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Build packages only (turbo)
-        run: pnpm turbo run build --filter=./packages/*
+        run: pnpm turbo run build --filter='./packages/*'
 
       - name: Typecheck examples
-        run: pnpm turbo run typecheck --filter=./examples/*
+        run: pnpm turbo run typecheck --filter='./examples/*'
+
+      - name: Typecheck apps
+        run: pnpm turbo run typecheck --filter='./apps/*'
 
   test:
     name: Test
@@ -101,4 +104,4 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Run package tests only (pnpm)
-        run: pnpm -r --filter=./packages/* --if-present test:run
+        run: pnpm -r --filter='./packages/*' --if-present test:run

--- a/apps/web-demo/package.json
+++ b/apps/web-demo/package.json
@@ -5,7 +5,8 @@
   "scripts": {
     "dev": "next dev --turbopack",
     "build": "next build --turbopack",
-    "start": "next start"
+    "start": "next start",
+    "typecheck": "tsc --noEmit"
   },
   "dependencies": {
     "@ai-sdk/react": "^2.0.52",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "sync:readme": "node scripts/sync-readmes.mjs root",
     "sync:pkg-readmes": "node scripts/sync-readmes.mjs packages",
     "sync:readmes": "node scripts/sync-readmes.mjs",
-    "pre-release": "pnpm format --fix && pnpm run build && pnpm run test:run",
+    "pre-release": "pnpm format --fix && pnpm run build && pnpm run typecheck && pnpm run test:run",
     "prerelease": "pnpm run pre-release",
     "release": "pnpm -r publish --access public --filter=\"@tokenlens/*\" --filter=tokenlens",
     "release:force": "pnpm -r publish --access public --filter=\"@tokenlens/*\" --filter=tokenlens --no-git-checks"


### PR DESCRIPTION
## Summary
- lint packages, apps, and examples in CI instead of packages only
- add a web-demo typecheck script and typecheck app workspaces in CI
- include root typecheck in the local pre-release path
- quote wildcard Turbo/pnpm filters in workflow commands so shells do not expand them

## Validation
- pnpm run format
- pnpm exec biome lint --reporter=summary packages apps examples
- pnpm run typecheck
- pnpm run build
- pnpm run test:run
- pnpm turbo run build --filter='./packages/*'
- pnpm turbo run typecheck --filter='./examples/*'
- pnpm turbo run typecheck --filter='./apps/*'
- pnpm -r --filter='./packages/*' --if-present test:run
- git diff --check origin/v2...HEAD